### PR TITLE
Use torch_proc_type in build string

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,6 +5,7 @@ context:
   version: "2.8.4"
   build_number: 4
   torch_proc_type: ${{ "cuda" if cuda_compiler_version != "None" else "cpu" }}
+  torch_proc_type_with_cuda_version: ${{ torch_proc_type ~ (cuda_compiler_version | replace(".", "") if torch_proc_type == "cuda" else "") }}
 
 package:
   name: ${{ name|lower }}
@@ -25,7 +26,7 @@ build:
   number: ${{ build_number }}
   skip:
     - win
-  string: ${{ torch_proc_type ~ (cuda_compiler_version | replace(".", "") if torch_proc_type == "cuda" else "_") ~ "py" ~ (python | version_to_buildstring) ~ "h" ~ hash ~ "_" ~ build_number }}
+  string: ${{ torch_proc_type_with_cuda_version ~ "_py" ~ (python | version_to_buildstring) ~ "h" ~ hash ~ "_" ~ build_number }}
   script:
     - export SETUPTOOLS_SCM_PRETEND_VERSION="${PKG_VERSION}"
     # TorchANI setup.py does not search the conda include directory; this lets

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   version: "2.8.4"
   build_number: 4
   torch_proc_type: ${{ "cuda" if cuda_compiler_version != "None" else "cpu" }}
-  torch_proc_type_with_cuda_version: ${{ torch_proc_type ~ (cuda_compiler_version | replace(".", "") if torch_proc_type == "cuda" else "") }}
+  torch_proc_type_with_cuda_version: ${{ "cuda" ~ cuda_compiler_version | replace(".", "") if cuda_compiler_version != "None" else "cpu" }}
 
 package:
   name: ${{ name|lower }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: torchani
   version: "2.8.4"
-  build_number: 3
+  build_number: 4
   torch_proc_type: ${{ "cuda" if cuda_compiler_version != "None" else "cpu" }}
 
 package:
@@ -25,7 +25,7 @@ build:
   number: ${{ build_number }}
   skip:
     - win
-  string: ${{ "cuda" ~ (cuda_compiler_version | replace(".", "")) ~ "py" ~ (python | version_to_buildstring) ~ "h" ~ hash ~ "_" ~ build_number if cuda_compiler_version != "None" else "cpu_py" ~ (python | version_to_buildstring) ~ "h" ~ hash ~ "_" ~ build_number }}
+  string: ${{ torch_proc_type ~ (cuda_compiler_version | replace(".", "") if torch_proc_type == "cuda" else "_") ~ "py" ~ (python | version_to_buildstring) ~ "h" ~ hash ~ "_" ~ build_number }}
   script:
     - export SETUPTOOLS_SCM_PRETEND_VERSION="${PKG_VERSION}"
     # TorchANI setup.py does not search the conda include directory; this lets


### PR DESCRIPTION
## Motivation

Follow-up to #69 and the review feedback in [this discussion](https://github.com/conda-forge/torchani-feedstock/pull/69#discussion_r3635369361). The recipe already defines `torch_proc_type` as the shared CPU/CUDA flavor, but the explicit build string repeated that decision and mixed `cpu_py...` with `cuda129py...`. Defining the version-aware flavor beside `torch_proc_type` with the same conditional shape makes their relationship obvious and keeps the final build string easy to read.

## Changes

- Define `torch_proc_type_with_cuda_version` alongside `torch_proc_type`, producing `cpu`, `cuda129`, or `cuda130`.
- Use a linear build-string expression with a consistent `_py` separator. CPU names remain `cpu_py...`; CUDA names become `cuda129_py...` and `cuda130_py...`.
- Bump the build number from 3 to 4 for the recipe-only rebuild.

## Local validation

```bash
conda-smithy recipe-lint --conda-forge recipe
conda-smithy rerender -c auto
```

Rerendering was idempotent and reported `No changes made. This feedstock is up-to-date.`

Representative CPU, CUDA 12.9, and CUDA 13.0 render/solve checks passed:

```bash
rattler-build build --recipe recipe/recipe.yaml --render-only --with-solve --target-platform linux-64 --variant-config .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonepython3.12.____cpython.yaml
rattler-build build --recipe recipe/recipe.yaml --render-only --with-solve --target-platform linux-64 --variant-config .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9python3.12.____cpython.yaml
rattler-build build --recipe recipe/recipe.yaml --render-only --with-solve --target-platform linux-64 --variant-config .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0python3.12.____cpython.yaml
```

The rendered package names are `cpu_py312h633328d_4`, `cuda129_py312h855b3dc_4`, and `cuda130_py312hfefe536_4`.
